### PR TITLE
fix: db assignments settings

### DIFF
--- a/backend/assignments/management/commands/create_test_assignments.py
+++ b/backend/assignments/management/commands/create_test_assignments.py
@@ -16,6 +16,7 @@ class Command(BaseCommand):
                 "subject_id": 4,  # 과학
                 "title": "호흡과 배설 단원 과제",
                 "description": "호흡 운동의 원리와 배설의 과정의 이해도를 평가하는 과제입니다.",
+                "total_questions": 3,
                 "visible_from": timezone.now(),
                 "due_at": timezone.now() + timedelta(days=2),
                 "grade": "중학교 2학년",
@@ -25,6 +26,7 @@ class Command(BaseCommand):
                 "subject_id": 3,  # 수학
                 "title": "함수의 개념 복습 과제",
                 "description": "함수의 정의를 복습하는 과제입니다.",
+                "total_questions": 3,
                 "visible_from": timezone.now(),
                 "due_at": timezone.now() + timedelta(days=10),
                 "grade": "초등학교 6학년",
@@ -34,6 +36,7 @@ class Command(BaseCommand):
                 "subject_id": 2,  # 영어
                 "title": "Reading Practice 1-A",
                 "description": "영어 독해 훈련 과제입니다.",
+                "total_questions": 3,
                 "visible_from": timezone.now(),
                 "due_at": timezone.now() + timedelta(days=5),
                 "grade": "중학교 3학년",
@@ -50,6 +53,7 @@ class Command(BaseCommand):
                 course_class_id=data["course_class"],
                 subject_id=data["subject_id"],
                 title=data["title"],
+                total_questions=data["total_questions"],
                 grade=data["grade"],
                 defaults={
                     "description": data["description"],


### PR DESCRIPTION
#### Related Issue(s):

dummy db setting command에 total_question이 세팅되지 않는 이슈

#### PR Description:

dummy question이 과제마다 3개 이므로 3추가

##### Changes Included:

- [ ] Added new feature(s)
- [x] Fixed identified bug(s)
- [ ] Updated relevant documentation

##### Screenshots (if UI changes were made):

Attach screenshots or GIFs of any visual changes. (Only for
frontend-related changes)

##### Notes for Reviewer:

Any specific instructions or points to be considered by the
reviewer.

---

#### Reviewer Checklist:

- [x] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as
      expected.
- [ ] Code review comments have been addressed or clarified.

---

#### Additional Comments:

total_question field의 의미가 각자 통일되지 않은거 같아서 통일이 되어야할 것 같음.

필자의 경우 total_question: base question의 개수라고 생각했음.
tail_question의 경우 statistics feature에서 따로 저장하지 않아도 db에서 금방 꺼내쓸 수 있고, assignment의 total_question이 personal_assignment의 solved_num과 대응된다고 생각해서 total_question의 개수를 tail_question이 생성될 때마다 바꾸면 개인별로 문항 수가 다 달라져서 동기화 문제가 생기기 때문에, total_question을 base question의 개수로 설정함.
