### PR TITLE
feat: made student registering button & feature

### DIFF
--- a/frontend/app/src/main/java/com/example/voicetutor/data/models/ClassModels.kt
+++ b/frontend/app/src/main/java/com/example/voicetutor/data/models/ClassModels.kt
@@ -23,6 +23,15 @@ data class ClassData(
     val endDate: String? = null
 )
 
+data class EnrollmentData(
+    @SerializedName("student")
+    val student: Student,
+    @SerializedName("course_class")
+    val courseClass: ClassData?,
+    @SerializedName("status")
+    val status: String
+)
+
 data class MessageData(
     @SerializedName("id")
     val id: Int,

--- a/frontend/app/src/main/java/com/example/voicetutor/data/network/ApiService.kt
+++ b/frontend/app/src/main/java/com/example/voicetutor/data/network/ApiService.kt
@@ -102,6 +102,15 @@ interface ApiService {
     @GET("courses/classes/{id}/students/")
     suspend fun getClassStudents(@Path("id") id: Int): Response<ApiResponse<List<Student>>>
     
+    // Enroll student to class (Backend: PUT /api/courses/classes/{id}/students/)
+    @PUT("courses/classes/{id}/students/")
+    suspend fun enrollStudentToClass(
+        @Path("id") id: Int,
+        @Query("studentId") studentId: Int? = null,
+        @Query("name") name: String? = null,
+        @Query("email") email: String? = null
+    ): Response<ApiResponse<EnrollmentData>>
+    
     // Message APIs (Backend: /api/feedbacks/messages/)
     @POST("feedbacks/messages/send/")
     suspend fun sendMessage(@Body request: SendMessageRequest): Response<ApiResponse<SendMessageResponse>>

--- a/frontend/app/src/main/java/com/example/voicetutor/data/repository/ClassRepository.kt
+++ b/frontend/app/src/main/java/com/example/voicetutor/data/repository/ClassRepository.kt
@@ -66,4 +66,27 @@ class ClassRepository @Inject constructor(
             Result.failure(e)
         }
     }
+
+    suspend fun enrollStudentToClass(
+        classId: Int,
+        studentId: Int? = null,
+        name: String? = null,
+        email: String? = null
+    ): Result<EnrollmentData> {
+        return try {
+            val response = apiService.enrollStudentToClass(
+                id = classId,
+                studentId = studentId,
+                name = name,
+                email = email
+            )
+            if (response.isSuccessful && response.body()?.success == true) {
+                Result.success(response.body()?.data ?: throw Exception("No data"))
+            } else {
+                Result.failure(Exception(response.body()?.error ?: "Unknown error"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
 }

--- a/frontend/app/src/main/java/com/example/voicetutor/ui/viewmodel/ClassViewModel.kt
+++ b/frontend/app/src/main/java/com/example/voicetutor/ui/viewmodel/ClassViewModel.kt
@@ -105,6 +105,22 @@ class ClassViewModel @Inject constructor(
         loadClasses(teacherId)
     }
     
+    fun enrollStudentToClass(classId: Int, studentId: Int? = null, name: String? = null, email: String? = null) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _error.value = null
+            classRepository.enrollStudentToClass(classId, studentId, name, email)
+                .onSuccess {
+                    // 등록 성공 후 해당 반 학생 목록 갱신
+                    loadClassStudents(classId)
+                }
+                .onFailure { e ->
+                    _error.value = e.message
+                }
+            _isLoading.value = false
+        }
+    }
+
     fun clearError() {
         _error.value = null
     }


### PR DESCRIPTION
### Add teacher-side student enrollment UI and API integration

#### Related Issue(s):
- N/A

#### PR Description:
Enables teachers to enroll students into a class directly from the class detail screen. Adds a bottom sheet UI to select from all available students and submit enrollments to the backend. Integrates with the new PUT /courses/classes/{id}/students/ endpoint and refreshes the class roster after successful enrollment.

##### Changes Included:
- [x] Added new feature(s)
- [ ] Fixed identified bug(s)
- [ ] Updated relevant documentation

Key implementation details:
- ApiService: add enrollStudentToClass PUT endpoint.
- ClassRepository: add enrollStudentToClass() method returning EnrollmentData.
- ClassViewModel: add enrollStudentToClass() method and refresh class students on success.
- TeacherClassDetailScreen: 
  - add “학생 등록하기” button.
  - show ModalBottomSheet with all students not yet in class.
  - multi-select via Checkbox; submit calls enroll for each selected student.
  - switch class student source to ClassViewModel.classStudents.
  - added @OptIn(ExperimentalMaterial3Api) for ModalBottomSheet.

##### Screenshots (if UI changes were made):
- Bottom sheet for enrollment (student selection)
- “학생 등록하기” button in Quick actions

##### Notes for Reviewer:
- Bottom sheet uses Material3 experimental API; we opted-in locally at the composable scope.
- Enroll submission currently sends one request per selected student; if needed, we can batch or parallelize later.
- After enrollment, class student list is refreshed via ClassViewModel.loadClassStudents().

---

#### Reviewer Checklist:
- [x] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [x] Manual testing has been performed to ensure the PR works as expected.
- [x] Code review comments have been addressed or clarified.

---

#### Additional Comments:
- Consider adding unit tests for ClassRepository.enrollStudentToClass and a UI test for the bottom sheet selection flow in a follow-up PR.