### PR TITLE
[Feat:teacher assignment result]

### DIFF
--- a/frontend/app/src/main/java/com/example/voicetutor/data/models/AssignmentModels.kt
+++ b/frontend/app/src/main/java/com/example/voicetutor/data/models/AssignmentModels.kt
@@ -180,6 +180,8 @@ data class StudentResult(
     val confidenceScore: Int,
     @SerializedName("status")
     val status: String,
+    @SerializedName("startedAt")
+    val startedAt: String? = null,
     @SerializedName("submittedAt")
     val submittedAt: String,
     @SerializedName("answers")

--- a/frontend/app/src/main/java/com/example/voicetutor/ui/screens/TeacherAssignmentResultsScreen.kt
+++ b/frontend/app/src/main/java/com/example/voicetutor/ui/screens/TeacherAssignmentResultsScreen.kt
@@ -321,7 +321,7 @@ fun TeacherAssignmentResultCard(
                         color = Gray600
                     )
                     Text(
-                        text = "정보 없음",
+                        text = formatDuration(student.startedAt, student.submittedAt),
                         style = MaterialTheme.typography.bodyMedium,
                         fontWeight = FontWeight.Medium,
                         color = Gray800
@@ -406,6 +406,52 @@ private fun getGradeColor(grade: String): Color {
         "D" -> Color(0xFFFF9800)
         "F" -> Error
         else -> Gray600
+    }
+}
+
+// Helper function to format duration between startedAt and submittedAt
+private fun formatDuration(startIso: String?, endIso: String?): String {
+    return try {
+        println("formatDuration start!")
+        if (startIso.isNullOrEmpty() || endIso.isNullOrEmpty()) {
+            println("startIso or endIso is null, $startIso || $endIso")
+            return "정보 없음"
+        }
+        val start = parseIsoToMillis(startIso)
+        val end = parseIsoToMillis(endIso)
+        if (start == null || end == null || end <= start) {
+            println("start or end is null $startIso ,$endIso")
+            return "정보 없음"
+        }
+        val diffMs = end - start
+        val totalSeconds = diffMs / 1000
+        val hours = (totalSeconds / 3600).toInt()
+        val minutes = ((totalSeconds % 3600) / 60).toInt()
+        val seconds = (totalSeconds % 60).toInt()
+        if (hours > 0) {
+            String.format("%02d:%02d:%02d", hours, minutes, seconds)
+        } else {
+            String.format("%02d:%02d", minutes, seconds)
+        }
+    } catch (e: Exception) {
+        println("FormatDuration: Exception!! $startIso $endIso")
+        "정보 없음"
+    }
+}
+
+// Parses basic ISO8601 like "yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'" or without fractional seconds
+private fun parseIsoToMillis(iso: String): Long? {
+    return try {
+        // Remove timezone 'Z' and fractional seconds for SimpleDateFormat compatibility
+        val cleaned = iso.replace("Z", "").let { raw ->
+            val dotIdx = raw.indexOf('.')
+            if (dotIdx != -1) raw.substring(0, dotIdx) else raw
+        }
+        val sdf = java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")
+        sdf.timeZone = java.util.TimeZone.getTimeZone("UTC")
+        sdf.parse(cleaned)?.time
+    } catch (e: Exception) {
+        null
     }
 }
 

--- a/frontend/app/src/main/java/com/example/voicetutor/ui/viewmodel/AssignmentViewModel.kt
+++ b/frontend/app/src/main/java/com/example/voicetutor/ui/viewmodel/AssignmentViewModel.kt
@@ -451,6 +451,7 @@ class AssignmentViewModel @Inject constructor(
                                                 !personalAssignment.startedAt.isNullOrEmpty() -> "진행 중"
                                                 else -> "미시작"
                                             },
+                                            startedAt = personalAssignment.startedAt,
                                             submittedAt = personalAssignment.submittedAt ?: personalAssignment.startedAt ?: "",
                                             answers = emptyList(),
                                             detailedAnswers = emptyList()


### PR DESCRIPTION
#### Related Issue(s):

Link or reference any related issues or tickets.

#### PR Description:

teacher assignment result page 연동 완료했고, 수업 전체 평균점수, 학생 개인 평균점수 반영 되는거 확인했습니다. 물론 학생 하나밖에 없어서 둘다 같은값이긴 합니다.
추가로 소요시간도 연동을 했는데, 현재 db상에 started_at이 없는건지 started_at 값이 null로 나와서 뜨지 않고 있습니다. sumitted_at값은 잘 받아집니다.
소요시간 연동과 평균점수 반영을 위해 PersonalAssignmentStatistics model과 PersonalAssignmentData model에 각각 average_score, started_at field를 추가했습니다. Statistics model은 전부 같은 api 쓸테니까 해당 값 다 받아올거고, started_at은 기본값 null로 해놨고 제가 처음 쓰는거니까 conflict error가 나지는 않을거라 판단합니다.

##### Changes Included:

- [ ] Added new feature(s)
- [ ] Fixed identified bug(s)
- [ ] Updated relevant documentation

##### Screenshots (if UI changes were made):

<img width="241" height="545" alt="스크린샷 2025-11-05 오전 1 04 51" src="https://github.com/user-attachments/assets/139bc481-9028-4349-bf4e-ac6a30661d59" />


##### Notes for Reviewer:

뭔가 문제가 있어보인다면 머지하지 말고 코멘트만 남겨주십쇼. 예비군 때문에 내일은 사라질 예정입니다.
---

#### Reviewer Checklist:

- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as
      expected.
- [ ] Code review comments have been addressed or clarified.

---

#### Additional Comments:
