### PR TITLE
fix: fixed account-deletion function

### DIFF
--- a/backend/core/authentication.py
+++ b/backend/core/authentication.py
@@ -1,0 +1,49 @@
+"""
+Custom JWT authentication that reads tokens from cookies.
+"""
+
+import logging
+
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework_simplejwt.exceptions import AuthenticationFailed, InvalidToken
+
+logger = logging.getLogger(__name__)
+
+
+class CookieJWTAuthentication(JWTAuthentication):
+    """
+    JWT authentication that reads the token from cookies instead of Authorization header.
+    Falls back to Authorization header if cookie is not present.
+    """
+
+    def authenticate(self, request):
+        # Try to get token from cookie first
+        access_token = request.COOKIES.get("access_token")
+
+        logger.info(f"[CookieJWTAuthentication] Path: {request.path}, Method: {request.method}")
+        logger.info(f"[CookieJWTAuthentication] Cookies: {list(request.COOKIES.keys())}")
+        logger.info(f"[CookieJWTAuthentication] access_token present: {bool(access_token)}")
+
+        if access_token:
+            # Validate the token from cookie
+            try:
+                validated_token = self.get_validated_token(access_token)
+                user = self.get_user(validated_token)
+                logger.info(f"[CookieJWTAuthentication] Authentication successful for user: {user.id}")
+                return (user, validated_token)
+            except (InvalidToken, AuthenticationFailed) as e:
+                logger.warning(f"[CookieJWTAuthentication] Invalid token from cookie: {e}")
+                # If cookie token is invalid, try Authorization header as fallback
+                pass
+
+        # Check Authorization header
+        auth_header = request.META.get("HTTP_AUTHORIZATION")
+        logger.info(f"[CookieJWTAuthentication] Authorization header present: {bool(auth_header)}")
+
+        # Fallback to Authorization header (standard JWT authentication)
+        result = super().authenticate(request)
+        if result:
+            logger.info("[CookieJWTAuthentication] Authentication successful via Authorization header")
+        else:
+            logger.warning("[CookieJWTAuthentication] Authentication failed - no valid token found")
+        return result

--- a/backend/voicetutor/settings.py
+++ b/backend/voicetutor/settings.py
@@ -177,7 +177,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.AllowAny",),
-    "DEFAULT_AUTHENTICATION_CLASSES": ("rest_framework_simplejwt.authentication.JWTAuthentication",),
+    "DEFAULT_AUTHENTICATION_CLASSES": ("core.authentication.CookieJWTAuthentication",),
 }
 
 REST_USE_JWT = True

--- a/frontend/app/src/main/java/com/example/voicetutor/data/network/TokenManager.kt
+++ b/frontend/app/src/main/java/com/example/voicetutor/data/network/TokenManager.kt
@@ -1,0 +1,48 @@
+package com.example.voicetutor.data.network
+
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TokenManager @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val prefs: SharedPreferences = context.getSharedPreferences("auth_prefs", Context.MODE_PRIVATE)
+    
+    companion object {
+        private const val KEY_ACCESS_TOKEN = "access_token"
+        private const val KEY_REFRESH_TOKEN = "refresh_token"
+    }
+    
+    fun saveAccessToken(token: String) {
+        prefs.edit().putString(KEY_ACCESS_TOKEN, token).apply()
+    }
+    
+    fun getAccessToken(): String? {
+        return prefs.getString(KEY_ACCESS_TOKEN, null)
+    }
+    
+    fun saveRefreshToken(token: String) {
+        prefs.edit().putString(KEY_REFRESH_TOKEN, token).apply()
+    }
+    
+    fun getRefreshToken(): String? {
+        return prefs.getString(KEY_REFRESH_TOKEN, null)
+    }
+    
+    fun clearTokens() {
+        prefs.edit()
+            .remove(KEY_ACCESS_TOKEN)
+            .remove(KEY_REFRESH_TOKEN)
+            .apply()
+    }
+    
+    fun hasToken(): Boolean {
+        return getAccessToken() != null
+    }
+}
+
+

--- a/frontend/app/src/main/java/com/example/voicetutor/di/NetworkModule.kt
+++ b/frontend/app/src/main/java/com/example/voicetutor/di/NetworkModule.kt
@@ -8,6 +8,9 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -37,10 +40,28 @@ object NetworkModule {
     
     @Provides
     @Singleton
+    fun provideCookieJar(): CookieJar {
+        return object : CookieJar {
+            private val cookieStore = mutableMapOf<String, List<Cookie>>()
+            
+            override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+                cookieStore[url.host] = cookies
+            }
+            
+            override fun loadForRequest(url: HttpUrl): List<Cookie> {
+                return cookieStore[url.host] ?: emptyList()
+            }
+        }
+    }
+    
+    @Provides
+    @Singleton
     fun provideOkHttpClient(
-        loggingInterceptor: HttpLoggingInterceptor
+        loggingInterceptor: HttpLoggingInterceptor,
+        cookieJar: CookieJar
     ): OkHttpClient {
         return OkHttpClient.Builder()
+            .cookieJar(cookieJar)
             .addInterceptor(loggingInterceptor)
             .connectTimeout(60, TimeUnit.SECONDS)
             .readTimeout(120, TimeUnit.SECONDS)


### PR DESCRIPTION
### PR Title: Fix account deletion authentication using request.user instead of manual token validation

#### Related Issue(s):

N/A

#### PR Description:

계정 삭제 API에서 쿠키에서 토큰을 직접 읽어 검증하던 방식을 Django의 인증 미들웨어를 활용한 `request.user` 기반 인증으로 변경했습니다. 또한 쿠키 기반 JWT 인증을 위한 커스텀 인증 클래스를 추가하고, Android 클라이언트에 쿠키 자동 관리 기능을 구현했습니다.

##### Changes Included:

- [x] Fixed identified bug(s)
- [ ] Added new feature(s)
- [ ] Updated relevant documentation

**Backend Changes:**
- `DeleteAccountView`: 쿠키에서 토큰을 직접 읽어 검증하던 로직 제거, `request.user.is_authenticated` 사용으로 변경
- `refresh_token` 관련 코드 제거 (계정 삭제 시 불필요)
- `CookieJWTAuthentication` 클래스 추가: 쿠키에서 `access_token`을 읽어 자동 인증 처리
- `settings.py`: 기본 인증 클래스를 `CookieJWTAuthentication`으로 변경

**Frontend Changes:**
- `NetworkModule.kt`: OkHttpClient에 `CookieJar` 추가하여 쿠키 자동 저장 및 전송 기능 구현

##### Screenshots (if UI changes were made):

N/A

##### Notes for Reviewer:

- 인증 로직이 미들웨어로 이동하여 코드가 더 간결해지고 Django 표준 방식에 맞춰졌습니다.
- 쿠키 기반 인증이 실패할 경우 Authorization 헤더로 폴백하도록 구현되어 있습니다.
- 인증 클래스에 로깅이 추가되어 있어 디버깅 시 쿠키 전송 여부를 확인할 수 있습니다.

---

#### Reviewer Checklist:

- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.

---

#### Additional Comments:

- 이전에 계정 삭제 시 401 에러가 발생하던 문제를 해결하기 위한 변경입니다.
- 쿠키 기반 인증이 제대로 작동하는지 확인하기 위해 서버 로그를 확인하는 것을 권장합니다.

