### PR TITLE
fix: update ui

### DIFF
--- a/frontend/app/src/main/java/com/example/voicetutor/ui/screens/CreateAssignmentScreen.kt
+++ b/frontend/app/src/main/java/com/example/voicetutor/ui/screens/CreateAssignmentScreen.kt
@@ -150,6 +150,7 @@ fun CreateAssignmentScreen(
     val zoneId = remember { ZoneId.systemDefault() }
 
     val classStudents by classViewModel.classStudents.collectAsStateWithLifecycle()
+    val isLoadingClassStudents by classViewModel.isLoading.collectAsStateWithLifecycle()
 
     val displayStudents = remember(selectedClassId, classStudents, students) {
         if (selectedClassId != null && classStudents.isNotEmpty()) {
@@ -719,9 +720,17 @@ fun CreateAssignmentScreen(
                                     modifier = Modifier.padding(start = 24.dp),
                                     verticalArrangement = Arrangement.spacedBy(8.dp),
                                 ) {
-                                    if (displayStudents.isEmpty()) {
+                                    if (isLoadingClassStudents) {
+                                        // 로딩 중인 경우
                                         Text(
                                             text = "학생 목록을 불러오는 중...",
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            color = Gray600,
+                                        )
+                                    } else if (displayStudents.isEmpty()) {
+                                        // 로딩 완료되었지만 학생이 없는 경우
+                                        Text(
+                                            text = "해당 반에 학생이 등록되지 않았습니다.",
                                             style = MaterialTheme.typography.bodyMedium,
                                             color = Gray600,
                                         )

--- a/frontend/app/src/main/java/com/example/voicetutor/ui/screens/TeacherAssignmentDetailScreen.kt
+++ b/frontend/app/src/main/java/com/example/voicetutor/ui/screens/TeacherAssignmentDetailScreen.kt
@@ -13,11 +13,14 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import android.widget.Toast
 import com.example.voicetutor.data.models.*
 import com.example.voicetutor.ui.components.*
 import com.example.voicetutor.ui.theme.*
@@ -317,7 +320,19 @@ fun TeacherAssignmentDetailScreen(
                         }
                     }
                 } else {
-                    students.forEachIndexed { index, student ->
+                    // 학생 목록 정렬: 완료 > 진행중 > 미시작
+                    val sortedStudents = remember(students) {
+                        students.sortedBy { student ->
+                            when (student.status) {
+                                "완료" -> 0
+                                "진행중" -> 1
+                                "미시작" -> 2
+                                else -> 3
+                            }
+                        }
+                    }
+                    
+                    sortedStudents.forEachIndexed { index, student ->
                         TeacherAssignmentResultCard(
                             student = student,
                             onStudentClick = {
@@ -328,7 +343,7 @@ fun TeacherAssignmentDetailScreen(
                             },
                         )
 
-                        if (index < students.size - 1) {
+                        if (index < sortedStudents.size - 1) {
                             Spacer(modifier = Modifier.height(8.dp))
                         }
                     }
@@ -343,11 +358,22 @@ fun TeacherAssignmentResultCard(
     student: StudentResult,
     onStudentClick: () -> Unit,
 ) {
+    val context = LocalContext.current
     val isCompleted = student.status == "완료"
+    val isNotStarted = student.status == "미시작"
+    val hasSubmittedAt = student.submittedAt.isNotBlank()
+
+    val handleClick: () -> Unit = {
+        if (isNotStarted) {
+            Toast.makeText(context, "아직 과제를 시작하지 않았습니다", Toast.LENGTH_SHORT).show()
+        } else {
+            onStudentClick()
+        }
+    }
 
     VTCard(
         variant = CardVariant.Elevated,
-        onClick = onStudentClick,
+        onClick = handleClick,
         modifier = Modifier.fillMaxWidth(),
     ) {
         Column(
@@ -391,54 +417,63 @@ fun TeacherAssignmentResultCard(
                 }
             }
 
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
+            if (!isNotStarted) {
+                // 진행 중이거나 완료된 경우 제출 정보 표시
                 Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
                 ) {
-                    Icon(
-                        imageVector = Icons.Filled.Schedule,
-                        contentDescription = null,
-                        tint = Gray500,
-                        modifier = Modifier.size(14.dp),
-                    )
-                    Text(
-                        text = "제출: ",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = Gray600,
-                    )
-                    Text(
-                        text = formatSubmittedTime(student.submittedAt),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = Gray600,
-                    )
-                }
+                    if (hasSubmittedAt) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Schedule,
+                                contentDescription = null,
+                                tint = Gray500,
+                                modifier = Modifier.size(14.dp),
+                            )
+                            Text(
+                                text = if (isCompleted) "제출: " else "최근 응시: ",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Gray600,
+                            )
+                            Text(
+                                text = formatSubmittedTime(student.submittedAt),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Gray600,
+                            )
+                        }
+                    } else {
+                        // 제출 시간이 없는 경우 공간 유지
+                        Spacer(modifier = Modifier.weight(1f))
+                    }
 
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                ) {
-                    Icon(
-                        imageVector = Icons.Filled.Grade,
-                        contentDescription = null,
-                        tint = Gray500,
-                        modifier = Modifier.size(14.dp),
-                    )
-                    Text(
-                        text = "점수: ",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = Gray600,
-                    )
-                    Text(
-                        text = "${student.score}점",
-                        style = MaterialTheme.typography.bodySmall,
-                        fontWeight = FontWeight.Medium,
-                        color = Gray800,
-                    )
+                    // 진행 중이거나 완료 상태일 때는 항상 점수 표시
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Grade,
+                            contentDescription = null,
+                            tint = Gray500,
+                            modifier = Modifier.size(14.dp),
+                        )
+                        Text(
+                            text = "점수: ",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Gray600,
+                        )
+                        Text(
+                            text = "${student.score}점",
+                            style = MaterialTheme.typography.bodySmall,
+                            fontWeight = FontWeight.Medium,
+                            color = Gray800,
+                        )
+                    }
                 }
             }
 

--- a/frontend/app/src/main/java/com/example/voicetutor/ui/screens/TeacherStudentAssignmentDetailScreen.kt
+++ b/frontend/app/src/main/java/com/example/voicetutor/ui/screens/TeacherStudentAssignmentDetailScreen.kt
@@ -34,12 +34,12 @@ private fun formatSubmittedTime(isoTime: String): String {
 private fun formatDuration(startIso: String?, endIso: String?): String {
     return try {
         if (startIso.isNullOrEmpty() || endIso.isNullOrEmpty()) {
-            return "정보 없음"
+            return "-"
         }
         val start = parseIsoToMillis(startIso)
         val end = parseIsoToMillis(endIso)
         if (start == null || end == null || end <= start) {
-            return "정보 없음"
+            return "-"
         }
         val diffMs = end - start
         val totalSeconds = diffMs / 1000
@@ -52,7 +52,7 @@ private fun formatDuration(startIso: String?, endIso: String?): String {
             String.format("%02d:%02d", minutes, seconds)
         }
     } catch (e: Exception) {
-        "정보 없음"
+        "-"
     }
 }
 


### PR DESCRIPTION
### PR Title: update ui

#### PR Description:
과제  상세에서 학생별 결과 ui 수정 미시작에는 제출 시간과 점수 안보이게, 진행 중일 때는 최근 응시로, 완료는 제출: 이런 식으로 보이도록 했고 미시작인 경우 아예 과제 결과 화면이 뜨지 못하게 하고 누른 경우 해당 과제가 시작되지 않았다고 toast 알림이 뜨도록 수정했습니다. 과제 결과에서도 정보 없음 대신 - 형태로 뜨도록 수정했습니다. 과제 생성 화면에서 반에 학생이 등록되지 않은 경우, 해당 반에 학생이 없다고 뜨도록 수정했습니다.

##### Changes Included:

- [ ] Added new feature(s)
- [ ] Fixed identified bug(s)
- [ ] Updated relevant documentation

##### Screenshots (if UI changes were made):
<img width="1080" height="2109" alt="image" src="https://github.com/user-attachments/assets/c5267942-0e16-42f4-a14e-b0c432614b10" />
<img width="1080" height="2132" alt="image" src="https://github.com/user-attachments/assets/7202859e-c142-4340-ae3a-c7d6a62f9a72" />
<img width="1080" height="1869" alt="image" src="https://github.com/user-attachments/assets/7728f6c2-f914-4f56-a42e-a849e9c07c08" />


##### Notes for Reviewer:

Any specific instructions or points to be considered by the
reviewer.

---

#### Reviewer Checklist:

- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as
      expected.
- [ ] Code review comments have been addressed or clarified.

---

#### Additional Comments:

Add any other comments or information that might be useful for the
review process.
